### PR TITLE
Fix proxy wait for response

### DIFF
--- a/src/handlebar/ProxyHelper.ts
+++ b/src/handlebar/ProxyHelper.ts
@@ -18,10 +18,10 @@ export class ProxyHelper {
   register = () => {
     this.Handlebars.registerHelper("proxy", (context: any) => {
       const options = JSON.parse(context.fn(this));
-      if (options.ssl.key && fs.existsSync(path.resolve(options.ssl.key))) {
+      if (options.ssl && options.ssl.key && fs.existsSync(path.resolve(options.ssl.key))) {
         options.ssl.key = fs.readFileSync(path.resolve(options.ssl.key))
       }
-      if (options.ssl.cert && fs.existsSync(path.resolve(options.ssl.cert))) {
+      if (options.ssl && options.ssl.cert && fs.existsSync(path.resolve(options.ssl.cert))) {
         options.ssl.cert = fs.readFileSync(path.resolve(options.ssl.cert))
       }
       if (options.target.pfx && fs.existsSync(path.resolve(options.target.pfx))) {

--- a/src/parser/HttpParser.ts
+++ b/src/parser/HttpParser.ts
@@ -211,6 +211,11 @@ export class HttpParser {
                 const proxyResponse: ProxyResponse = JSON.parse(responseBody);
                 /* eslint-disable no-case-declarations */
                 proxy.web(this.req, this.res, proxyResponse.options);
+                // Wait for proxy response
+                await new Promise((resolve, reject) => {
+                  proxy.on("proxyRes", resolve)
+                  proxy.on("error", reject)
+                })
                 break;
               case "fault":
                 const faultType = codeResponse["FaultType"];
@@ -261,6 +266,7 @@ export class HttpParser {
                 logger: logger,
               })}`
             );
+            response.status = 500;
             response.body = await template({
               request: this.req,
               logger: logger,


### PR DESCRIPTION
# Description

This PR includes 3 fixes:
1. Proxy was not waiting for response, so it didn't work
2. Proxy configuration requires optional `ssl` option
3. On parser error, the response status code was `200` (replaced to `500`)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
```
{
    "target": "https://random-data-api.com/api/users/random_user",
    "followRedirects": false,
    "changeOrigin": true,
    "ignorePath": true
}
```
* OS: MacOS
* Node version: 20.11.0
* NPM Version: 10.2.4

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] This does not break any existing functionalities
- [X] Any dependent changes have been merged and published in downstream modules
