### PR TITLE
fix(config): change the default schema URL for petstore

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -61,7 +61,7 @@ validation:
   enable: true
   schemas:
     - type: OpenApi
-      url: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json
+      url: https://raw.githubusercontent.com/OAI/learn.openapis.org/refs/heads/main/examples/v3.0/petstore.json
 # ext_helpers: "./custom_handlebar.json"
 # ext_data_source:
 #   pg:


### PR DESCRIPTION
# Description

Since last week, the PetStore JSON schema has been removed from the OpenAPI spec (_see [this commit](https://github.com/OAI/OpenAPI-Specification/commit/18bf2771eb98f19cdcb1c23d45d8c2a1f49a54d8)_). It has been moved to the [learn.openapis.org repo](https://github.com/OAI/learn.openapis.org/blob/main/examples/v3.0/petstore.json).

When running the camouflage server with the default config, we've got 404 HTTP errors :

```
Couldn't load OpenApi validation schema https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json, because: Error downloading https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json 
```

- Change the OpenAPI validator URL to the learn OpenAPI repo

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just run `npm run start` now and call the `GET http://localhost:8080`, there should be no more 404 errors.

**Test Configuration**:
* OS: MacOS 15.0.1
* Node version: v20.15.0
* NPM Version: v10.7.0

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
